### PR TITLE
Skip `checksum32` tests if `crc32` is missing

### DIFF
--- a/numcodecs/tests/test_checksum32.py
+++ b/numcodecs/tests/test_checksum32.py
@@ -3,7 +3,11 @@ import itertools
 import numpy as np
 import pytest
 
-from numcodecs.checksum32 import CRC32, CRC32C, Adler32
+try:
+    from numcodecs.checksum32 import CRC32, CRC32C, Adler32
+except ImportError:  # pragma: no cover
+    pytest.skip("numcodecs.checksum32 not available", allow_module_level=True)
+
 from numcodecs.tests.common import (
     check_backwards_compatibility,
     check_config,


### PR DESCRIPTION
If `crc32` is not installed, skip the tests in `test_checksum32.py`.

<hr>

TODO:

- [ ] Unit tests and/or doctests in docstrings
- [ ] Tests pass locally
- [ ] Docstrings and API docs for any new/modified user-facing classes and functions
- [ ] Changes documented in docs/release.rst
- [ ] Docs build locally
- [ ] GitHub Actions CI passes
- [ ] Test coverage to 100% (Codecov passes)
